### PR TITLE
Update the Playout Statistics API for WebAudio spec with a formal algorithm

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,9 +129,12 @@ A more detailed discussion about security and privacy can be found in the [Secur
 
 ### Cross-site covert channeling
 
-In Chromium, Safari and Firefox it is already possible to intentionally communicate between different origins using audio glitches ([see explanation here](https://github.com/w3ctag/design-reviews/issues/939#issuecomment-2022954199)). This side channel has a very high latency, is audible to the user, and degrades system performance, so it is unlikely to be useful to attackers. 
+In Chromium, Safari and Firefox it is already possible to intentionally communicate between different origins using audio glitches ([see explanation here](https://github.com/w3ctag/design-reviews/issues/939#issuecomment-2022954199), or the concern by the Privacy WG raised [here](https://github.com/WICG/web_audio_playout/issues/4)). This side channel has a very high latency, is audible to the user, and degrades system performance. The introduction of the Playout Statistics API for WebAudio should not reduce the latency of this side channel, or make it more effective. For this reason, the API should implement two mitigations:
 
-It would be good if the introduction of the Playout Statistics API for WebAudio does not reduce the latency of this side channel. We could do this by limiting the rate at which the information provided by the API is updated, similar to the [Rate limitation used for the ComputePressure API](https://www.w3.org/TR/compute-pressure/#rate-limiting-change-notifications). This would increase the latency of any attempts to communicate using the glitch information, ensuring that the audio glitch-based side channel is not made more useful.
+* The values returned by the API should only update once per second (similar to the [Rate limitation used for the ComputePressure API](https://www.w3.org/TR/compute-pressure/#rate-limiting-change-notifications)).
+* The values returned by the API should only update if the site is visible or has `getUserMedia` permission.
+
+For more in-depth discussion about this concern and this mitigation, see [the spec](https://wicg.github.io/web_audio_playout/#security-privacy-considerations).
 
 ## Comparison to [WebAudio RenderCapacity API](https://github.com/w3ctag/design-reviews/issues/843)
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ A more detailed discussion about security and privacy can be found in the [Secur
 
 ### Cross-site covert channeling
 
-In Chromium, Safari and Firefox it is already possible to intentionally communicate between different origins using audio glitches ([see explanation here](https://github.com/w3ctag/design-reviews/issues/939#issuecomment-2022954199), or the concern by the Privacy WG raised [here](https://github.com/WICG/web_audio_playout/issues/4)). This side channel has a very high latency, is audible to the user, and degrades system performance. The introduction of the Playout Statistics API for WebAudio should not reduce the latency of this side channel, or make it more effective. For this reason, the API should implement two mitigations:
+With current browsers it is already possible to intentionally communicate between different origins using audio glitches ([see explanation here](https://github.com/w3ctag/design-reviews/issues/939#issuecomment-2022954199), or the concern by the Privacy WG raised [here](https://github.com/WICG/web_audio_playout/issues/4)). This side channel has a very high latency, is audible to the user, and degrades system performance. The introduction of the Playout Statistics API for WebAudio should not reduce the latency of this side channel, or make it more effective. For this reason, the API should implement two mitigations:
 
 * The values returned by the API should only update once per second (similar to the [Rate limitation used for the ComputePressure API](https://www.w3.org/TR/compute-pressure/#rate-limiting-change-notifications)).
 * The values returned by the API should only update if the site is visible or has `getUserMedia` permission.

--- a/index.html
+++ b/index.html
@@ -60,6 +60,25 @@
       Glitches and high latency are bad for the user experience, so if any of these occur it can be useful for the
       application to be able to detect this and possibly take some action to improve the playout.
     </p>
+    <p>
+
+          The {{AudioContext/AudioPlayoutStats}} under AudioContext is a dedicated object for statistics reporting;
+          Similar to <a href="https://w3c.github.io/webrtc-stats/#dom-rtcaudioplayoutstats">RTCAudioPlayoutStats</a>,
+           but it is for the playout path via AudioDestinationNode and the associated output device.
+          This will allow us to measure glitches occurring due to underperforming AudioWorklets as well as glitches and
+          delay occurring in the playout path between the AudioContext and the output device.
+    </p>
+    <p>
+      Audio glitches are expressed in terms of fallback frames and fallback events.
+      
+      Fallback frames are frames played by the output device that were not provided
+by the playout path. This happens when the playout path fails to provide audio frames
+to the output device on time, in which case fallback frames will be played. This typically
+only happens if the pipeline is underperforming. In the Chromium implementation, fallback
+frames are always silence. This includes underrun situations that happen for reasons unrelated to WebAudio/AudioWorklets.
+    
+  A fallback event is a continuous interval of fallback frames being played. When a fallback frame is played after a non-fallback frame, we consider this a fallback event.
+</p>
   </section>
   <section data-dfn-for="AudioContext">
     <h2>Extension of the <a href="https://webaudio.github.io/web-audio-api/#AudioContext"><dfn>AudioContext</dfn></a>
@@ -70,20 +89,26 @@
       [SameObject] readonly attribute AudioPlayoutStats playoutStats;
     };
     </pre>
+    AudioContext has the following internal slots:
+    [[playout stats]] An instance of AudioPlayoutStats.
+
+
     <p>
     <section>
       <h2>Attributes</h2>
       <section>
         <h2><dfn>playoutStats</dfn> attribute</h2>
         <p>
-          The {{AudioContext/AudioPlayoutStats}} under AudioContext is a dedicated object for statistics reporting;
-          Similar to <a href="https://w3c.github.io/webrtc-stats/#dom-rtcaudioplayoutstats">RTCAudioPlayoutStats</a>,
-           but it is for the playout path via AudioDestinationNode and the associated output device.
-          This will allow us to measure glitches occurring due to underperforming AudioWorklets as well as glitches and
-          delay occurring in the playout path between the AudioContext and the output device.</p>
+          If the [[playout stats]] slot is null, initialize the slot with the result of the *initialize playout stats* algorithm, with /this/ as input.
+          Return the value of the [[playout stats]] internal slot.
+
+          When the AudioContext is in the "running" state, once per second, the *update playout stats* algorithm runs with /playout stats/ as input.
+
+          Move this to some explanatory section:</p>
       </section>
     </section>
     </p>
+
   </section>
   <section data-dfn-for="AudioPlayoutStats">
     <h2><dfn>AudioPlayoutStats</dfn> interface</h2>
@@ -100,6 +125,18 @@
       [Default] object toJSON();
     };
     </pre>
+
+    It has the following internal slots:
+
+    [[fallback frames duration]]
+    [[fallback frames events]]
+    [[total frames duration]]
+    [[average latency]]
+    [[minimum latency]]
+    [[maximum latency]]
+    [[latency reset time]]
+    [[audio context]]
+
     <section>
       <h2>Attributes</h2>
       <section>
@@ -108,40 +145,58 @@
           each time a fallback frame is played by the output device at the end of the playout path. This metric can be
           used together with {{AudioPlayoutStats/totalFramesDuration}} to calculate the percentage of played out media
           that was not provided by the AudioContext.
+
+           Returns [[fallback frames duration]].
         </p>
       </section>
       <section>
         <h2><dfn>fallbackFramesEvents</dfn> attribute</h2>
-        <p>This measures the number of synthesized fallback frames events.
+        <p>
+          This measures the number of synthesized fallback frames events.
           This counter increases every time a fallback frame is played after a non-fallback frame. That is, multiple
           consecutive fallback frames will increase {{AudioPlayoutStats/fallbackFramesDuration}} multiple times but is a
           single fallback
           frames event.
+
+          Returns [[fallback frames events]].
         </p>
       </section>
       <section>
         <h2><dfn>totalFramesDuration</dfn> attribute</h2>
         <p>This attribute is the total duration, in milliseconds, of all audio
-          frames that have been played by the audio device. Includes both fallback and non-fallback frames.</p>
+          frames that have been played by the audio device. Includes both fallback and non-fallback frames.
+        
+        
+          Returns [[total frames duration]].
+        </p>
       </section>
       <section>
         <h2><dfn>averageLatency</dfn> attribute</h2>
         <p>This is the average latency for the frames played since the
           last call to {{AudioPlayoutStats/resetLatency()}}, or since the creation of the AudioContext if
           {{AudioPlayoutStats/resetLatency()}} has
-          not been called.</p>
+          not been called.
+        
+          Returns [[average latency]].
+        </p>
       </section>
       <section>
         <h2><dfn>minimumLatency</dfn> attribute</h2>
         <p>This measures the minimum latency for the frames played since the
           last call to {{AudioPlayoutStats/resetLatency()}}, or since the creation of the AudioContext if
-          {{AudioPlayoutStats/resetLatency()}} has not been called. </p>
+          {{AudioPlayoutStats/resetLatency()}} has not been called. 
+        
+        
+          Returns [[minimum latency]].
+        </p>
       </section>
       <section>
         <h2><dfn>maximumLatency</dfn> attribute</h2>
         <p>This measures the maximum latency for the frames played since the
           last call to {{AudioPlayoutStats/resetLatency()}}, or since the creation of the AudioContext if
           {{AudioPlayoutStats/resetLatency()}} has not been called.
+        
+          Returns [[maximum latency]].
         </p>
       </section>
     </section>
@@ -150,10 +205,47 @@
       <section>
         <h2><dfn>resetLatency</dfn> method</h2>
         <p>This method resets the latency counters. Note that it does not remove
-          latency information that has accrued but not yet been exposed through the API.</p>
+          latency information that has accrued but not yet been exposed through the API.
+        
+          When resetLatency is called, run these steps:
+          1. Let /current latency/ be the playout latency of the last frame.
+          2. Set [[latency reset time]] to the current time.
+          3. Set [[average latency]] to /current latency/.
+          4. Set [[minimum latency]] to /current latency/.
+          5. Set [[maximum latency]] to /current latency/.
+        </p>
       </section>
     </section>
+
+
+
+    
+    The *initialize playout stats* algorithm means running these steps:
+    1. Let /owning audio context/ be the AudioContext passed into this algorithm
+    2. Let /playout stats/ be a new instance of AudioPlayoutStats
+    3. Set [[audio context]] in /playout stats/ to /owning audio context/
+    4. Set [[latency reset time]] in /playout stats/ to the current time.
+    5. Return /playout stats/
+
+
+    The *update playout stats* algorithm means running these steps:
+    1. If [[audio context]] is not running, abort these steps
+    2. Let /document/ be the current objects associated document
+    3. Let /can_update/ be false
+    4. If /document/ is fully active, set /can_update/ to true
+    Let permission be the result of the permission state for the descriptor whose name is "microphone".
+    If /permission/ is "granted", set /can_update/ to true
+    6. If /can_update/ is false, abort these steps.
+    7. Set [[fallback frames duration]] to the total duration of all fallback frames (in milliseconds) that [[audio context]] has played since the creation of [[audio context]].
+    8. Set [[fallback frames events]] to the number of times that [[audio context]] has played a fallback frame after a non-fallback frame since the creation of [[audio context]].
+    9. Set [[total frames duration]] to the total duration of all frames (in milliseconds) that [[audio context]] has played since the creation of [[audio context]].
+    10. Set [[average latency]] to the average playout latency (in milliseconds) for frames played by [[audio context]] since [[latency reset time]].
+    11. Set [[minimum latency]] to the minimum playout latency (in milliseconds) for frames played by [[audio context]] since [[latency reset time]].
+    12. Set [[maximum latency]] to the maximum playout latency (in milliseconds) for frames played by [[audio context]] since [[latency reset time]].
+
+
   </section>
+
   <section id="usage">
     <h2>Usage Example</h2>
     This is an example of how the API can be used to calculate the following stats over a time interval:

--- a/index.html
+++ b/index.html
@@ -63,11 +63,11 @@
     </p>
     <p>
 
-          The {{AudioContext/AudioPlayoutStats}} under AudioContext is a dedicated object for statistics reporting;
+          The {{AudioContext/AudioPlayoutStats}} under {{AudioContext}} is a dedicated object for statistics reporting;
           Similar to <a href="https://w3c.github.io/webrtc-stats/#dom-rtcaudioplayoutstats">RTCAudioPlayoutStats</a>,
-           but it is for the playout path via AudioDestinationNode and the associated output device.
-          This will allow us to measure glitches occurring due to underperforming AudioWorklets as well as glitches and
-          delay occurring in the playout path between the AudioContext and the output device.
+           but it is for the playout path via {{AudioDestinationNode}} and the associated output device.
+          This will allow us to measure glitches occurring due to underperforming {{AudioWorklet}}s as well as glitches and
+          delay occurring in the playout path between the {{AudioContext}} and the output device.
     </p>
     <p>
       Audio glitches are expressed in terms of fallback frames and fallback events.
@@ -75,7 +75,7 @@
       <li>A <dfn>fallback frame</dfn> is an audio frame played by the output device that was not provided
 by the playout path. This happens when the playout path fails to provide audio frames
 to the output device on time, in which case fallback frames will be played (fallback frames are typically silence). This typically
-only happens if the pipeline is underperforming. This includes underrun situations that happen for reasons unrelated to WebAudio/AudioWorklets.</li>
+only happens if the pipeline is underperforming. This includes underrun situations that happen for reasons unrelated to WebAudio/{{AudioWorklet}}s.</li>
     
   <li>A <dfn>fallback event</dfn> is a continuous interval of fallback frames being played. When a fallback frame is played after a non-fallback frame, we consider this a fallback event.</li>
   </ul>
@@ -91,7 +91,7 @@ only happens if the pipeline is underperforming. This includes underrun situatio
     };
     </pre>
     <p>
-    AudioContext has the following internal slot:
+    {{AudioContext}} has the following internal slot:
     <dfn class=export data-dfn-for="AudioContext">[[\playout stats]]</dfn>, An instance of {{AudioContext/AudioPlayoutStats}}, initially null.
     </p>
 
@@ -107,7 +107,7 @@ only happens if the pipeline is underperforming. This includes underrun situatio
           <li>Return the value of the {{AudioContext/[[playout stats]]}} internal slot.</li>
           </ol>
 
-          When the AudioContext is in the "running" state, once per second, the [= update playout stats =] algorithm runs on {{AudioContext/[[playout stats]]}}.
+          When the {{AudioContext}} is in the "running" state, once per second, the [= update playout stats =] algorithm runs on {{AudioContext/[[playout stats]]}}.
 
           </p>
       </section>
@@ -134,11 +134,11 @@ only happens if the pipeline is underperforming. This includes underrun situatio
     It has the following internal slots:
     <dl>
       <dt data-md><dfn class=export data-dfn-for="AudioPlayoutStats">[[\fallback frames duration]]</dfn></dt>
-      <dd data-md><p>A timestamp representing the total duration of fallback frames that the AudioContext has played as of the last stat update. Initialized to 0.</p></dd>
+      <dd data-md><p>A timestamp representing the total duration of fallback frames that the {{AudioContext}} has played as of the last stat update. Initialized to 0.</p></dd>
       <dt data-md><dfn class=export data-dfn-for="AudioPlayoutStats">[[\fallback frames events]]</dfn></dt>
       <dd data-md>And integer representing the total number of fallback events that have occurred as of the last stat update. Initialized to 0.</dd>
       <dt data-md><dfn class=export data-dfn-for="AudioPlayoutStats">[[\total frames duration]]</dfn></dt>
-      <dd data-md>A timestamp representing the total duration of all audio frames that the AudioContext has played as of the last stat update. Initialized to 0.</dd>
+      <dd data-md>A timestamp representing the total duration of all audio frames that the {{AudioContext}} has played as of the last stat update. Initialized to 0.</dd>
       <dt data-md><dfn class=export data-dfn-for="AudioPlayoutStats">[[\average latency]]</dfn></dt>
       <dd data-md>A timestamp representing the average playout latency over the currently tracked interval.</dd>
       <dt data-md><dfn class=export data-dfn-for="AudioPlayoutStats">[[\minimum latency]]</dfn></dt>
@@ -161,7 +161,7 @@ only happens if the pipeline is underperforming. This includes underrun situatio
         <p>Returns {{AudioPlayoutStats/[[fallback frames duration]]}}.</p>
         <p>Measures the duration of [=fallback frame=]s played by the {{AudioContext}}, in milliseconds. This metric can be
           used together with {{AudioPlayoutStats/totalFramesDuration}} to calculate the percentage of played out media
-          that was not provided by the AudioContext.
+          that was not provided by the {{AudioContext}}.
         </p>
       </section>
       <section>
@@ -181,7 +181,7 @@ only happens if the pipeline is underperforming. This includes underrun situatio
         <h2><dfn>averageLatency</dfn> attribute</h2>
         <p>Returns {{AudioPlayoutStats/[[average latency]]}}.</p>
         <p>This is the average latency for the frames played since the
-          last call to {{AudioPlayoutStats/resetLatency()}}, or since the creation of the AudioContext if
+          last call to {{AudioPlayoutStats/resetLatency()}}, or since the creation of the {{AudioContext}} if
           {{AudioPlayoutStats/resetLatency()}} has
           not been called.
         </p>
@@ -190,7 +190,7 @@ only happens if the pipeline is underperforming. This includes underrun situatio
         <h2><dfn>minimumLatency</dfn> attribute</h2>
         <p>Returns {{AudioPlayoutStats/[[minimum latency]]}}.</p>
         <p>This measures the minimum latency for the frames played since the
-          last call to {{AudioPlayoutStats/resetLatency()}}, or since the creation of the AudioContext if
+          last call to {{AudioPlayoutStats/resetLatency()}}, or since the creation of the {{AudioContext}} if
           {{AudioPlayoutStats/resetLatency()}} has not been called. 
         </p>
       </section>
@@ -198,7 +198,7 @@ only happens if the pipeline is underperforming. This includes underrun situatio
         <h2><dfn>maximumLatency</dfn> attribute</h2>
         <p>Returns {{AudioPlayoutStats/[[maximum latency]]}}.</p>
         <p>This measures the maximum latency for the frames played since the
-          last call to {{AudioPlayoutStats/resetLatency()}}, or since the creation of the AudioContext if
+          last call to {{AudioPlayoutStats/resetLatency()}}, or since the creation of the {{AudioContext}} if
           {{AudioPlayoutStats/resetLatency()}} has not been called.
         </p>
       </section>
@@ -230,7 +230,7 @@ only happens if the pipeline is underperforming. This includes underrun situatio
     <p>
     The <dfn>initialize playout stats</dfn> algorithm means running these steps:
     <ol>
-      <li>Let <var>owning audio context</var> be the AudioContext passed into this algorithm.</li>
+      <li>Let <var>owning audio context</var> be the {{AudioContext}} passed into this algorithm.</li>
       <li>Let <var>playout stats</var> be a new instance of AudioPlayoutStats.</li>
       <li>Set {{AudioPlayoutStats/[[audio context]]}} in <var>playout stats</var> to <var>owning audio context</var>.</li>
       <li>Set {{AudioPlayoutStats/[[latency reset time]]}} in <var>playout stats</var> to the current time.</li>

--- a/index.html
+++ b/index.html
@@ -70,15 +70,16 @@
           delay occurring in the playout path between the AudioContext and the output device.
     </p>
     <p>
-      Audio glitches are expressed in terms of fallback frames and fallback events. <br/>
-      
-      Fallback frames are frames played by the output device that were not provided
+      Audio glitches are expressed in terms of fallback frames and fallback events.
+      <ul>
+      <li>A <dfn>fallback frame</dfn> is an audio frame played by the output device that was not provided
 by the playout path. This happens when the playout path fails to provide audio frames
 to the output device on time, in which case fallback frames will be played. This typically
 only happens if the pipeline is underperforming. In the Chromium implementation, fallback
-frames are always silence. This includes underrun situations that happen for reasons unrelated to WebAudio/AudioWorklets.
+frames are always silence. This includes underrun situations that happen for reasons unrelated to WebAudio/AudioWorklets.</li>
     
-  A fallback event is a continuous interval of fallback frames being played. When a fallback frame is played after a non-fallback frame, we consider this a fallback event.
+  <li>A <dfn>fallback event</dfn> is a continuous interval of fallback frames being played. When a fallback frame is played after a non-fallback frame, we consider this a fallback event.</li>
+  </ul>
 </p>
   </section>
   <section data-dfn-for="AudioContext">
@@ -92,7 +93,7 @@ frames are always silence. This includes underrun situations that happen for rea
     </pre>
     <p>
     AudioContext has the following internal slot:
-    <dfn class=export data-dfn-for="AudioContext">[[\playout stats]]</dfn>, An instance of {{AudioContext/AudioPlayoutStats}}.
+    <dfn class=export data-dfn-for="AudioContext">[[\playout stats]]</dfn>, An instance of {{AudioContext/AudioPlayoutStats}}, initially null.
     </p>
 
     <p>
@@ -107,9 +108,9 @@ frames are always silence. This includes underrun situations that happen for rea
           <li>Return the value of the {{AudioContext/[[playout stats]]}} internal slot.</li>
           </ol>
 
-          When the AudioContext is in the "running" state, once per second, the *update playout stats* algorithm runs with /playout stats/ as input.
+          When the AudioContext is in the "running" state, once per second, the [= update playout stats =] algorithm runs on {{AudioContext/[[playout stats]]}}.
 
-          Move this to some explanatory section:</p>
+          </p>
       </section>
     </section>
     </p>
@@ -155,62 +156,48 @@ frames are always silence. This includes underrun situations that happen for rea
       <h2>Attributes</h2>
       <section>
         <h2><dfn>fallbackFramesDuration</dfn> attribute</h2>
-        <p>This value is measured in milliseconds and is incremented
-          each time a fallback frame is played by the output device at the end of the playout path. This metric can be
+        <p>Returns {{AudioPlayoutStats/[[fallback frames duration]]}}.</p>
+        <p>Measures the duration of [=fallback frame=]s played by the {{AudioContext}}, in milliseconds. This metric can be
           used together with {{AudioPlayoutStats/totalFramesDuration}} to calculate the percentage of played out media
           that was not provided by the AudioContext.
-
-           Returns {{AudioPlayoutStats/[[fallback frames duration]]}}.
         </p>
       </section>
       <section>
         <h2><dfn>fallbackFramesEvents</dfn> attribute</h2>
+        <p>Returns {{AudioPlayoutStats/[[fallback frames events]]}}.</p>
         <p>
-          This measures the number of synthesized fallback frames events.
-          This counter increases every time a fallback frame is played after a non-fallback frame. That is, multiple
-          consecutive fallback frames will increase {{AudioPlayoutStats/fallbackFramesDuration}} multiple times but is a
-          single fallback
-          frames event.
-
-          Returns {{AudioPlayoutStats/[[fallback frames events]]}}.
+          This measures the number of [=fallback event=]s that have occurred in the {{AudioContext}}.
         </p>
       </section>
       <section>
         <h2><dfn>totalFramesDuration</dfn> attribute</h2>
-        <p>This attribute is the total duration, in milliseconds, of all audio
-          frames that have been played by the audio device. Includes both fallback and non-fallback frames.
-        
-        
-          Returns [[total frames duration]].
+        <p>Returns {{AudioPlayoutStats/[[total frames duration]]}}.</p>
+        <p>>Measures the duration of all audio frames played by the {{AudioContext}}, in milliseconds. Includes both fallback and non-fallback frames.
         </p>
       </section>
       <section>
         <h2><dfn>averageLatency</dfn> attribute</h2>
+        <p>Returns {{AudioPlayoutStats/[[average latency]]}}.</p>
         <p>This is the average latency for the frames played since the
           last call to {{AudioPlayoutStats/resetLatency()}}, or since the creation of the AudioContext if
           {{AudioPlayoutStats/resetLatency()}} has
           not been called.
-        
-          Returns [[average latency]].
         </p>
       </section>
       <section>
         <h2><dfn>minimumLatency</dfn> attribute</h2>
+        <p>Returns {{AudioPlayoutStats/[[minimum latency]]}}.</p>
         <p>This measures the minimum latency for the frames played since the
           last call to {{AudioPlayoutStats/resetLatency()}}, or since the creation of the AudioContext if
           {{AudioPlayoutStats/resetLatency()}} has not been called. 
-        
-        
-          Returns [[minimum latency]].
         </p>
       </section>
       <section>
         <h2><dfn>maximumLatency</dfn> attribute</h2>
+        <p>Returns {{AudioPlayoutStats/[[maximum latency]]}}.</p>
         <p>This measures the maximum latency for the frames played since the
           last call to {{AudioPlayoutStats/resetLatency()}}, or since the creation of the AudioContext if
           {{AudioPlayoutStats/resetLatency()}} has not been called.
-        
-          Returns [[maximum latency]].
         </p>
       </section>
     </section>
@@ -220,46 +207,52 @@ frames are always silence. This includes underrun situations that happen for rea
         <h2><dfn>resetLatency</dfn> method</h2>
         <p>This method resets the latency counters. Note that it does not remove
           latency information that has accrued but not yet been exposed through the API.
-        
-          When resetLatency is called, run these steps:
-          1. Let /current latency/ be the playout latency of the last frame.
-          2. Set [[latency reset time]] to the current time.
-          3. Set [[average latency]] to /current latency/.
-          4. Set [[minimum latency]] to /current latency/.
-          5. Set [[maximum latency]] to /current latency/.
+        </p>
+        <p>
+          When <code>resetLatency()</code> is called, run these steps:
+          <ol>
+            <li>Let <var>current latency</var> be the playout latency of the last frame.</li>
+            <li>Set {{AudioPlayoutStats/[[latency reset time]]}} to the current time.</li>
+            <li>Set {{AudioPlayoutStats/[[average latency]]}} to <var>current latency</var>.</li>
+            <li>Set {{AudioPlayoutStats/[[minimum latency]]}} to <var>current latency</var>.</li>
+            <li>Set {{AudioPlayoutStats/[[maximum latency]]}} to <var>current latency</var>.</li>
+          </ol>
         </p>
       </section>
     </section>
 
 
     <section>
+    <h2>Internal algorithms</h2>
 
     <p>
     The <dfn>initialize playout stats</dfn> algorithm means running these steps:
     <ol>
-    <li>Let /owning audio context/ be the AudioContext passed into this algorithm</li>
-    <li>Let /playout stats/ be a new instance of AudioPlayoutStats</li>
-    <li>Set [[audio context]] in /playout stats/ to /owning audio context/</li>
-    <li>Set [[latency reset time]] in /playout stats/ to the current time.</li>
-    <li>Return /playout stats/</li>
+      <li>Let <var>owning audio context</var> be the AudioContext passed into this algorithm</li>
+      <li>Let <var>playout stats</var> be a new instance of AudioPlayoutStats</li>
+      <li>Set {{AudioPlayoutStats/[[audio context]]}} in <var>playout stats</var> to <var>owning audio context</var></li>
+      <li>Set {{AudioPlayoutStats/[[latency reset time]]}} in <var>playout stats</var> to the current time.</li>
+      <li>Return <var>playout stats</var></li>
     </ol>
     </p>
 
 <p>
-    The *update playout stats* algorithm means running these steps:
-    1. If [[audio context]] is not running, abort these steps
-    2. Let /document/ be the current objects associated document
-    3. Let /can_update/ be false
-    4. If /document/ is fully active, set /can_update/ to true
-    Let permission be the result of the permission state for the descriptor whose name is "microphone".
-    If /permission/ is "granted", set /can_update/ to true
-    6. If /can_update/ is false, abort these steps.
-    7. Set [[fallback frames duration]] to the total duration of all fallback frames (in milliseconds) that [[audio context]] has played since the creation of [[audio context]].
-    8. Set [[fallback frames events]] to the number of times that [[audio context]] has played a fallback frame after a non-fallback frame since the creation of [[audio context]].
-    9. Set [[total frames duration]] to the total duration of all frames (in milliseconds) that [[audio context]] has played since the creation of [[audio context]].
-    10. Set [[average latency]] to the average playout latency (in milliseconds) for frames played by [[audio context]] since [[latency reset time]].
-    11. Set [[minimum latency]] to the minimum playout latency (in milliseconds) for frames played by [[audio context]] since [[latency reset time]].
-    12. Set [[maximum latency]] to the maximum playout latency (in milliseconds) for frames played by [[audio context]] since [[latency reset time]].
+  Running <dfn>update playout stats</dfn> algorithm on an {{AudioPlayoutStats}} means running these steps: 
+    <ol>
+    <li>If {{AudioPlayoutStats/[[audio context]]}} is not running, abort these steps</li>
+    <li>Let <var>document</var> be the current objects associated document</li> 
+    <li>Let <var>can_update</var> be false</li> 
+    <li>If <var>document</var> is fully active, set <var>can_update</var> to true</li> 
+    <li>Let <var>permission</var> be the [=permission state=] for the permission associated with microphone access. 
+    If <var>permission</var> is "granted", set <var>can_update</var> to true</li>
+    <li>If <var>can_update</var> is false, abort these steps.</li>
+    <li>Set {{AudioPlayoutStats/[[fallback frames duration]]}} to the total duration of all fallback frames (in milliseconds) that {{AudioPlayoutStats/[[audio context]]}} has played since the creation of {{AudioPlayoutStats/[[audio context]]}}.</li> 
+    <li>Set {{AudioPlayoutStats/[[fallback frames events]]}} to the number of times that {{AudioPlayoutStats/[[audio context]]}} has played a fallback frame after a non-fallback frame since the creation of {{AudioPlayoutStats/[[audio context]]}}.</li> 
+    <li>Set {{AudioPlayoutStats/[[total frames duration]]}} to the total duration of all frames (in milliseconds) that {{AudioPlayoutStats/[[audio context]]}} has played since the creation of {{AudioPlayoutStats/[[audio context]]}}.</li> 
+    <li>Set {{AudioPlayoutStats/[[average latency]]}} to the average playout latency (in milliseconds) for frames played by {{AudioPlayoutStats/[[audio context]]}} since {{AudioPlayoutStats/[[latency reset time]]}}.</li> 
+    <li>Set {{AudioPlayoutStats/[[minimum latency]]}} to the minimum playout latency (in milliseconds) for frames played by {{AudioPlayoutStats/[[audio context]]}} since {{AudioPlayoutStats/[[latency reset time]]}}.</li> 
+    <li>Set {{AudioPlayoutStats/[[maximum latency]]}} to the maximum playout latency (in milliseconds) for frames played by {{AudioPlayoutStats/[[audio context]]}} since {{AudioPlayoutStats/[[latency reset time]]}}.</li> 
+  </ol>
 </p>
 
     </section>

--- a/index.html
+++ b/index.html
@@ -30,6 +30,7 @@
       "shortName": "audio_context_playout_stats",
       "specStatus": "unofficial",
       "wg": "WICG",
+      "xref": ["geometry-1", "html", "infra", "permissions", "dom", "hr-time", "image-capture", "mediacapture-streams", "screen-capture", "webaudio", "webcodecs", "webidl"],
     };
   </script>
 </head>
@@ -69,7 +70,7 @@
           delay occurring in the playout path between the AudioContext and the output device.
     </p>
     <p>
-      Audio glitches are expressed in terms of fallback frames and fallback events.
+      Audio glitches are expressed in terms of fallback frames and fallback events. <br/>
       
       Fallback frames are frames played by the output device that were not provided
 by the playout path. This happens when the playout path fails to provide audio frames
@@ -89,9 +90,10 @@ frames are always silence. This includes underrun situations that happen for rea
       [SameObject] readonly attribute AudioPlayoutStats playoutStats;
     };
     </pre>
-    AudioContext has the following internal slots:
-    [[playout stats]] An instance of AudioPlayoutStats.
-
+    <p>
+    AudioContext has the following internal slot:
+    <dfn class=export data-dfn-for="AudioContext">[[\playout stats]]</dfn>, An instance of {{AudioContext/AudioPlayoutStats}}.
+    </p>
 
     <p>
     <section>
@@ -99,8 +101,11 @@ frames are always silence. This includes underrun situations that happen for rea
       <section>
         <h2><dfn>playoutStats</dfn> attribute</h2>
         <p>
-          If the [[playout stats]] slot is null, initialize the slot with the result of the *initialize playout stats* algorithm, with /this/ as input.
-          Return the value of the [[playout stats]] internal slot.
+          When accessing this attribute, run the following steps:
+          <ol>
+          <li>If the {{AudioContext/[[playout stats]]}} slot is null, initialize the slot with the result of the [= initialize playout stats =] algorithm, with <i>this</i> as input.</li>
+          <li>Return the value of the {{AudioContext/[[playout stats]]}} internal slot.</li>
+          </ol>
 
           When the AudioContext is in the "running" state, once per second, the *update playout stats* algorithm runs with /playout stats/ as input.
 
@@ -127,15 +132,24 @@ frames are always silence. This includes underrun situations that happen for rea
     </pre>
 
     It has the following internal slots:
-
-    [[fallback frames duration]]
-    [[fallback frames events]]
-    [[total frames duration]]
-    [[average latency]]
-    [[minimum latency]]
-    [[maximum latency]]
-    [[latency reset time]]
-    [[audio context]]
+    <dl>
+      <dt data-md><dfn class=export data-dfn-for="AudioPlayoutStats">[[\fallback frames duration]]</dfn></dt>
+      <dd data-md><p>A timestamp representing the total duration of fallback frames that the AudioContext has played as of the last stat update. Initialized to 0.</p></dd>
+      <dt data-md><dfn class=export data-dfn-for="AudioPlayoutStats">[[\fallback frames events]]</dfn></dt>
+      <dd data-md>And integer representing the total number of fallback events that have occurred as of the last stat update. Initialized to 0.</dd>
+      <dt data-md><dfn class=export data-dfn-for="AudioPlayoutStats">[[\total frames duration]]</dfn></dt>
+      <dd data-md>A timestamp representing the total duration of all audio frames that the AudioContext has played as of the last stat update. Initialized to 0.</dd>
+      <dt data-md><dfn class=export data-dfn-for="AudioPlayoutStats">[[\average latency]]</dfn></dt>
+      <dd data-md>A timestamp representing the average playout latency over the currently tracked interval.</dd>
+      <dt data-md><dfn class=export data-dfn-for="AudioPlayoutStats">[[\minimum latency]]</dfn></dt>
+      <dd data-md>A timestamp representing the minimum playout latency over the currently tracked interval.</dd>
+      <dt data-md><dfn class=export data-dfn-for="AudioPlayoutStats">[[\maximum latency]]</dfn></dt>
+      <dd data-md>A timestamp representing the maximum playout latency over the currently tracked interval.</dd>
+      <dt data-md><dfn class=export data-dfn-for="AudioPlayoutStats">[[\latency reset time]]</dfn></dt>
+      <dd data-md>A timestamp representing time that the latency statistics time was created on.</dd>
+      <dt data-md><dfn class=export data-dfn-for="AudioPlayoutStats"> [[\audio context]]</dfn></dt>
+      <dd data-md>The {{AudioContext}} owning the {{AudioPlayoutStats}} instance.</dd>
+    </dl>
 
     <section>
       <h2>Attributes</h2>
@@ -146,7 +160,7 @@ frames are always silence. This includes underrun situations that happen for rea
           used together with {{AudioPlayoutStats/totalFramesDuration}} to calculate the percentage of played out media
           that was not provided by the AudioContext.
 
-           Returns [[fallback frames duration]].
+           Returns {{AudioPlayoutStats/[[fallback frames duration]]}}.
         </p>
       </section>
       <section>
@@ -158,7 +172,7 @@ frames are always silence. This includes underrun situations that happen for rea
           single fallback
           frames event.
 
-          Returns [[fallback frames events]].
+          Returns {{AudioPlayoutStats/[[fallback frames events]]}}.
         </p>
       </section>
       <section>
@@ -218,16 +232,20 @@ frames are always silence. This includes underrun situations that happen for rea
     </section>
 
 
+    <section>
 
-    
-    The *initialize playout stats* algorithm means running these steps:
-    1. Let /owning audio context/ be the AudioContext passed into this algorithm
-    2. Let /playout stats/ be a new instance of AudioPlayoutStats
-    3. Set [[audio context]] in /playout stats/ to /owning audio context/
-    4. Set [[latency reset time]] in /playout stats/ to the current time.
-    5. Return /playout stats/
+    <p>
+    The <dfn>initialize playout stats</dfn> algorithm means running these steps:
+    <ol>
+    <li>Let /owning audio context/ be the AudioContext passed into this algorithm</li>
+    <li>Let /playout stats/ be a new instance of AudioPlayoutStats</li>
+    <li>Set [[audio context]] in /playout stats/ to /owning audio context/</li>
+    <li>Set [[latency reset time]] in /playout stats/ to the current time.</li>
+    <li>Return /playout stats/</li>
+    </ol>
+    </p>
 
-
+<p>
     The *update playout stats* algorithm means running these steps:
     1. If [[audio context]] is not running, abort these steps
     2. Let /document/ be the current objects associated document
@@ -242,8 +260,9 @@ frames are always silence. This includes underrun situations that happen for rea
     10. Set [[average latency]] to the average playout latency (in milliseconds) for frames played by [[audio context]] since [[latency reset time]].
     11. Set [[minimum latency]] to the minimum playout latency (in milliseconds) for frames played by [[audio context]] since [[latency reset time]].
     12. Set [[maximum latency]] to the maximum playout latency (in milliseconds) for frames played by [[audio context]] since [[latency reset time]].
+</p>
 
-
+    </section>
   </section>
 
   <section id="usage">

--- a/index.html
+++ b/index.html
@@ -213,6 +213,10 @@ only happens if the pipeline is underperforming. This includes underrun situatio
         <p>
           When <code>resetLatency()</code> is called, run the [= reset latency stats =] steps.
         </p>
+        <div class="note">
+          <p>Calling <code>resetLatency()</code> and reading any of the latency attributes immediately after will yield the same value as <a
+        href="https://webaudio.github.io/web-audio-api/#dom-audiocontext-outputlatency"><code>AudioContext.outputLatency</code></a>.</p>
+        </div>
       </section>
     </section>
 
@@ -249,7 +253,7 @@ only happens if the pipeline is underperforming. This includes underrun situatio
     <li>Let <var>document</var> be the current object's <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-document-window">associated document</a>.</li> 
     <li>Let <var>canUpdate</var> be false.</li> 
     <li>If <var>document</var> is <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#fully-active">fully active</a> and <a href="https://html.spec.whatwg.org/multipage/interaction.html#page-visibility">visible</a>, set <var>canUpdate</var> to true.</li>
-    <li>Let <var>permission</var> be the [=permission state=] for the permission associated with microphone access. 
+    <li>Let <var>permission</var> be the [=permission state=] for the permission associated with [="microphone"=] access. 
     If <var>permission</var> is "granted", set <var>canUpdate</var> to true.</li>
     <li>If <var>canUpdate</var> is false, abort these steps.</li>
     <li>Set {{AudioPlayoutStats/[[fallback frames duration]]}} to the total duration of all fallback frames (in milliseconds) that {{AudioPlayoutStats/[[audio context]]}} has played since the creation of {{AudioPlayoutStats/[[audio context]]}}.</li> 

--- a/index.html
+++ b/index.html
@@ -316,7 +316,7 @@ let playoutDelay = audioContext.playoutStats.averageLatency / 1000;
     <p>To inihibit the usage of this covert channel, implementers should apply these mitigations.</p>
     <h4>Rate-limiting</h4>
     <p>
-      Implementers should not update the glitch stats returned by the API more often than once per second. This limits the bandwidth of the covert channel.
+      Implementers should not update the values returned by the API more often than once per second. This limits the bandwidth of the covert channel.
     </p>
     <h4>Restricting API access</h4>
     <p>

--- a/index.html
+++ b/index.html
@@ -211,14 +211,7 @@ only happens if the pipeline is underperforming. This includes underrun situatio
           latency information that has accrued but not yet been exposed through the API.
         </p>
         <p>
-          When <code>resetLatency()</code> is called, run these steps:
-          <ol>
-            <li>Let <var>current latency</var> be the playout latency of the last frame.</li>
-            <li>Set {{AudioPlayoutStats/[[latency reset time]]}} to the current time.</li>
-            <li>Set {{AudioPlayoutStats/[[average latency]]}} to <var>current latency</var>.</li>
-            <li>Set {{AudioPlayoutStats/[[minimum latency]]}} to <var>current latency</var>.</li>
-            <li>Set {{AudioPlayoutStats/[[maximum latency]]}} to <var>current latency</var>.</li>
-          </ol>
+          When <code>resetLatency()</code> is called, run the [= reset latency stats =] steps.
         </p>
       </section>
     </section>
@@ -228,26 +221,37 @@ only happens if the pipeline is underperforming. This includes underrun situatio
     <h2>Internal algorithms</h2>
 
     <p>
-    The <dfn>initialize playout stats</dfn> algorithm means running these steps:
+    Running the <dfn>initialize playout stats</dfn> algorithm means running these steps:
     <ol>
-      <li>Let <var>owning audio context</var> be the {{AudioContext}} passed into this algorithm.</li>
-      <li>Let <var>playout stats</var> be a new instance of AudioPlayoutStats.</li>
-      <li>Set {{AudioPlayoutStats/[[audio context]]}} in <var>playout stats</var> to <var>owning audio context</var>.</li>
-      <li>Set {{AudioPlayoutStats/[[latency reset time]]}} in <var>playout stats</var> to the current time.</li>
-      <li>Return <var>playout stats</var>.</li>
+      <li>Let <var>owningAudioContext</var> be the {{AudioContext}} passed into this algorithm.</li>
+      <li>Let <var>playoutStats</var> be a new instance of {{AudioPlayoutStats}}.</li>
+      <li>Set {{AudioPlayoutStats/[[audio context]]}} in <var>playoutStats</var> to <var>owningAudioContext</var>.</li>
+      <li>Run the [= reset latency stats =] steps.</li>
+      <li>Return <var>playoutStats</var>.</li>
     </ol>
-    </p>
+  </p>
 
 <p>
-  Running <dfn>update playout stats</dfn> algorithm on an {{AudioPlayoutStats}} means running these steps: 
+  Running the <dfn>reset latency stats</dfn> algorithm on an {{AudioPlayoutStats}} means running these steps: 
+  <ol>
+      <li>Let <var>currentLatency</var> be the playout latency of the last frame played by {{AudioPlayoutStats/[[audio context]]}}, or 0 if no frames have been played out yet.</li>
+      <li>Set {{AudioPlayoutStats/[[latency reset time]]}} to the current time.</li>
+      <li>Set {{AudioPlayoutStats/[[average latency]]}} to <var>currentLatency</var>.</li>
+      <li>Set {{AudioPlayoutStats/[[minimum latency]]}} to <var>currentLatency</var>.</li>
+      <li>Set {{AudioPlayoutStats/[[maximum latency]]}} to <var>currentLatency</var>.</li>
+    </ol>
+</p>
+
+<p>
+  Running the <dfn>update playout stats</dfn> algorithm on an {{AudioPlayoutStats}} means running these steps: 
     <ol>
     <li>If {{AudioPlayoutStats/[[audio context]]}} is not running, abort these steps.</li>
-    <li>Let <var>document</var> be the current objects associated document.</li> 
-    <li>Let <var>can_update</var> be false.</li> 
-    <li>If <var>document</var> is fully active, set <var>can_update</var> to true.</li> 
+    <li>Let <var>document</var> be the current object's <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-document-window">associated document</a>.</li> 
+    <li>Let <var>canUpdate</var> be false.</li> 
+    <li>If <var>document</var> is <a href="https://html.spec.whatwg.org/multipage/document-sequences.html#fully-active">fully active</a> and <a href="https://html.spec.whatwg.org/multipage/interaction.html#page-visibility">visible</a>, set <var>canUpdate</var> to true.</li>
     <li>Let <var>permission</var> be the [=permission state=] for the permission associated with microphone access. 
-    If <var>permission</var> is "granted", set <var>can_update</var> to true.</li>
-    <li>If <var>can_update</var> is false, abort these steps.</li>
+    If <var>permission</var> is "granted", set <var>canUpdate</var> to true.</li>
+    <li>If <var>canUpdate</var> is false, abort these steps.</li>
     <li>Set {{AudioPlayoutStats/[[fallback frames duration]]}} to the total duration of all fallback frames (in milliseconds) that {{AudioPlayoutStats/[[audio context]]}} has played since the creation of {{AudioPlayoutStats/[[audio context]]}}.</li> 
     <li>Set {{AudioPlayoutStats/[[fallback frames events]]}} to the number of times that {{AudioPlayoutStats/[[audio context]]}} has played a fallback frame after a non-fallback frame since the creation of {{AudioPlayoutStats/[[audio context]]}}.</li> 
     <li>Set {{AudioPlayoutStats/[[total frames duration]]}} to the total duration of all frames (in milliseconds) that {{AudioPlayoutStats/[[audio context]]}} has played since the creation of {{AudioPlayoutStats/[[audio context]]}}.</li> 

--- a/index.html
+++ b/index.html
@@ -214,7 +214,7 @@ only happens if the pipeline is underperforming. This includes underrun situatio
           When <code>resetLatency()</code> is called, run the [= reset latency stats =] steps.
         </p>
         <div class="note">
-          <p>Calling <code>resetLatency()</code> and reading any of the latency attributes immediately after will yield the same value as <a
+          <p>Calling <code>resetLatency()</code> and reading any of the latency attributes immediately after will yield a similar latency to <a
         href="https://webaudio.github.io/web-audio-api/#dom-audiocontext-outputlatency"><code>AudioContext.outputLatency</code></a>.</p>
         </div>
       </section>

--- a/index.html
+++ b/index.html
@@ -213,10 +213,6 @@ only happens if the pipeline is underperforming. This includes underrun situatio
         <p>
           When <code>resetLatency()</code> is called, run the [= reset latency stats =] steps.
         </p>
-        <div class="note">
-          <p>Calling <code>resetLatency()</code> and reading any of the latency attributes immediately after will yield a similar latency to <a
-        href="https://webaudio.github.io/web-audio-api/#dom-audiocontext-outputlatency"><code>AudioContext.outputLatency</code></a>.</p>
-        </div>
       </section>
     </section>
 
@@ -320,7 +316,7 @@ let playoutDelay = audioContext.playoutStats.averageLatency / 1000;
     <p>To inihibit the usage of this covert channel, implementers should apply these mitigations.</p>
     <h4>Rate-limiting</h4>
     <p>
-      Implementers should not update the values returned by the API more often than once per second. This limits the bandwidth of the covert channel.
+      Implementers should not update the glitch stats returned by the API more often than once per second. This limits the bandwidth of the covert channel.
     </p>
     <h4>Restricting API access</h4>
     <p>

--- a/index.html
+++ b/index.html
@@ -74,9 +74,8 @@
       <ul>
       <li>A <dfn>fallback frame</dfn> is an audio frame played by the output device that was not provided
 by the playout path. This happens when the playout path fails to provide audio frames
-to the output device on time, in which case fallback frames will be played. This typically
-only happens if the pipeline is underperforming. In the Chromium implementation, fallback
-frames are always silence. This includes underrun situations that happen for reasons unrelated to WebAudio/AudioWorklets.</li>
+to the output device on time, in which case fallback frames will be played (fallback frames are typically silence). This typically
+only happens if the pipeline is underperforming. This includes underrun situations that happen for reasons unrelated to WebAudio/AudioWorklets.</li>
     
   <li>A <dfn>fallback event</dfn> is a continuous interval of fallback frames being played. When a fallback frame is played after a non-fallback frame, we consider this a fallback event.</li>
   </ul>
@@ -154,6 +153,9 @@ frames are always silence. This includes underrun situations that happen for rea
 
     <section>
       <h2>Attributes</h2>
+      <div class="note">
+        <p>These attributes update only once per second and under specific conditions. See the <a href="#mitigations">Privacy & Security mitigations</a> section and the [= update playout stats =] algorithm for details.</p>
+      </div>
       <section>
         <h2><dfn>fallbackFramesDuration</dfn> attribute</h2>
         <p>Returns {{AudioPlayoutStats/[[fallback frames duration]]}}.</p>
@@ -172,7 +174,7 @@ frames are always silence. This includes underrun situations that happen for rea
       <section>
         <h2><dfn>totalFramesDuration</dfn> attribute</h2>
         <p>Returns {{AudioPlayoutStats/[[total frames duration]]}}.</p>
-        <p>>Measures the duration of all audio frames played by the {{AudioContext}}, in milliseconds. Includes both fallback and non-fallback frames.
+        <p>Measures the duration of all audio frames played by the {{AudioContext}}, in milliseconds. Includes both fallback and non-fallback frames.
         </p>
       </section>
       <section>
@@ -228,23 +230,23 @@ frames are always silence. This includes underrun situations that happen for rea
     <p>
     The <dfn>initialize playout stats</dfn> algorithm means running these steps:
     <ol>
-      <li>Let <var>owning audio context</var> be the AudioContext passed into this algorithm</li>
-      <li>Let <var>playout stats</var> be a new instance of AudioPlayoutStats</li>
-      <li>Set {{AudioPlayoutStats/[[audio context]]}} in <var>playout stats</var> to <var>owning audio context</var></li>
+      <li>Let <var>owning audio context</var> be the AudioContext passed into this algorithm.</li>
+      <li>Let <var>playout stats</var> be a new instance of AudioPlayoutStats.</li>
+      <li>Set {{AudioPlayoutStats/[[audio context]]}} in <var>playout stats</var> to <var>owning audio context</var>.</li>
       <li>Set {{AudioPlayoutStats/[[latency reset time]]}} in <var>playout stats</var> to the current time.</li>
-      <li>Return <var>playout stats</var></li>
+      <li>Return <var>playout stats</var>.</li>
     </ol>
     </p>
 
 <p>
   Running <dfn>update playout stats</dfn> algorithm on an {{AudioPlayoutStats}} means running these steps: 
     <ol>
-    <li>If {{AudioPlayoutStats/[[audio context]]}} is not running, abort these steps</li>
-    <li>Let <var>document</var> be the current objects associated document</li> 
-    <li>Let <var>can_update</var> be false</li> 
-    <li>If <var>document</var> is fully active, set <var>can_update</var> to true</li> 
+    <li>If {{AudioPlayoutStats/[[audio context]]}} is not running, abort these steps.</li>
+    <li>Let <var>document</var> be the current objects associated document.</li> 
+    <li>Let <var>can_update</var> be false.</li> 
+    <li>If <var>document</var> is fully active, set <var>can_update</var> to true.</li> 
     <li>Let <var>permission</var> be the [=permission state=] for the permission associated with microphone access. 
-    If <var>permission</var> is "granted", set <var>can_update</var> to true</li>
+    If <var>permission</var> is "granted", set <var>can_update</var> to true.</li>
     <li>If <var>can_update</var> is false, abort these steps.</li>
     <li>Set {{AudioPlayoutStats/[[fallback frames duration]]}} to the total duration of all fallback frames (in milliseconds) that {{AudioPlayoutStats/[[audio context]]}} has played since the creation of {{AudioPlayoutStats/[[audio context]]}}.</li> 
     <li>Set {{AudioPlayoutStats/[[fallback frames events]]}} to the number of times that {{AudioPlayoutStats/[[audio context]]}} has played a fallback frame after a non-fallback frame since the creation of {{AudioPlayoutStats/[[audio context]]}}.</li> 
@@ -306,7 +308,7 @@ let playoutDelay = audioContext.playoutStats.averageLatency / 1000;
     <p>
       The glitch information provided by the API could be used to form a cross-site covert channel between two cooperating webstites. One site could transmit information by intentionally causing audio glitches (by causing very high CPU usage, for example) while the other site could use the API to detect these glitches.
     </p>
-    <h3>Mitigations</h3>
+    <h3 id="mitigations">Mitigations</h3>
     <p>To inihibit the usage of this covert channel, implementers should apply these mitigations.</p>
     <h4>Rate-limiting</h4>
     <p>

--- a/index.html
+++ b/index.html
@@ -77,7 +77,7 @@ by the playout path. This happens when the playout path fails to provide audio f
 to the output device on time, in which case fallback frames will be played (fallback frames are typically silence). This typically
 only happens if the pipeline is underperforming. This includes underrun situations that happen for reasons unrelated to WebAudio/{{AudioWorklet}}s.</li>
     
-  <li>A <dfn>fallback event</dfn> is a continuous interval of fallback frames being played. When a fallback frame is played after a non-fallback frame, we consider this a fallback event.</li>
+  <li>When a fallback frame is played after a non-fallback frame, we consider this a <dfn>fallback event</dfn>. That is, multiple consecutive fallback frames will count as a single fallback event.</li>
   </ul>
 </p>
   </section>
@@ -235,7 +235,7 @@ only happens if the pipeline is underperforming. This includes underrun situatio
   Running the <dfn>reset latency stats</dfn> algorithm on an {{AudioPlayoutStats}} means running these steps: 
   <ol>
       <li>Let <var>currentLatency</var> be the playout latency of the last frame played by {{AudioPlayoutStats/[[audio context]]}}, or 0 if no frames have been played out yet.</li>
-      <li>Set {{AudioPlayoutStats/[[latency reset time]]}} to the current time.</li>
+      <li>Set {{AudioPlayoutStats/[[latency reset time]]}} to the <a href="https://www.w3.org/TR/compute-pressure/#ref-for-dfn-timestamp-1">current time</a>.</li>
       <li>Set {{AudioPlayoutStats/[[average latency]]}} to <var>currentLatency</var>.</li>
       <li>Set {{AudioPlayoutStats/[[minimum latency]]}} to <var>currentLatency</var>.</li>
       <li>Set {{AudioPlayoutStats/[[maximum latency]]}} to <var>currentLatency</var>.</li>


### PR DESCRIPTION
This algorithm also formalizes the implementation of the privacy and security mitigations.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Hernqvist/web_audio_playout/pull/6.html" title="Last updated on Jun 25, 2025, 7:56 AM UTC (a3e9009)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/web_audio_playout/6/4c62931...Hernqvist:a3e9009.html" title="Last updated on Jun 25, 2025, 7:56 AM UTC (a3e9009)">Diff</a>